### PR TITLE
Custom validator class to resolve issue #13

### DIFF
--- a/router-config-generator/templates/home.html
+++ b/router-config-generator/templates/home.html
@@ -23,6 +23,10 @@ onload="clearForm()"
       document.getElementById('lan_dhcpv4_excluded_last').style.display = "none"
     }
   }
+  
+  window.onload = function() {
+  	check_dhcpv4_exclusions();
+  }
 </script>
 <script>
   function ClearForm() 

--- a/router-config-generator/templates/home.html
+++ b/router-config-generator/templates/home.html
@@ -146,11 +146,25 @@ onload="clearForm()"
         <fieldset class="form-field" id="lan_dhcpv4_excluded_first" style="display: none">
           {{ form.lan_dhcpv4_excluded_first.label }}
           {{ form.lan_dhcpv4_excluded_first }}
+          {% if form.lan_dhcpv4_excluded_first.errors %}
+          <ul class="errors">
+            {% for error in form.lan_dhcpv4_excluded_first.errors %}
+              <li>{{ error }}</li>
+            {% endfor %}
+          </ul>
+          {% endif %}
         </fieldset>
 
         <fieldset class="form-field" id="lan_dhcpv4_excluded_last" style="display: none">
           {{ form.lan_dhcpv4_excluded_last.label }}
           {{ form.lan_dhcpv4_excluded_last }}
+          {% if form.lan_dhcpv4_excluded_last.errors %}
+          <ul class="errors">
+            {% for error in form.lan_dhcpv4_excluded_last.errors %}
+              <li>{{ error }}</li>
+            {% endfor %}
+          </ul>
+          {% endif %}
         </fieldset>
 
         <fieldset class="form-field">


### PR DESCRIPTION
Added ValidateIfDHCPExclusionsEnabled class to resolve issue #13.

Validators are evaluated in listed order. The class checks whether the lan_dhcpv4_exclusions field is True/False. If the value is False, then it stops validation. If it's True, then the IPAddress validator is run.

Added error message to home.html for the DHCP exclusion fields.